### PR TITLE
Drop unspecified SCRAM(-PLUS) variants

### DIFF
--- a/aiosasl/__init__.py
+++ b/aiosasl/__init__.py
@@ -633,9 +633,6 @@ class SCRAMBase:
         # a value of 1 is added if the -PLUS variant is used
         # -- JWI
         "SHA-1": ("sha1", 1),
-        "SHA-224": ("sha224", 224),
-        "SHA-512": ("sha512", 512),
-        "SHA-384": ("sha384", 384),
         "SHA-256": ("sha256", 256),
     }
 

--- a/tests/test_aiosasl.py
+++ b/tests/test_aiosasl.py
@@ -397,8 +397,7 @@ class TestPLAIN(unittest.TestCase):
 
 class TestSCRAMNegotiation(unittest.TestCase):
     def test_supports_SCRAM_famliy(self):
-        hashes = ["SHA-1", "SHA-224", "SHA-256",
-                  "SHA-512", "SHA-384", "SHA-256"]
+        hashes = ["SHA-1", "SHA-256"]
 
         for hashname in hashes:
             mechanism = "SCRAM-{}".format(hashname)
@@ -408,8 +407,7 @@ class TestSCRAMNegotiation(unittest.TestCase):
             )
 
     def test_supports_SCRAMPLUS_famliy(self):
-        hashes = ["SHA-1", "SHA-224", "SHA-256",
-                  "SHA-512", "SHA-384", "SHA-256"]
+        hashes = ["SHA-1", "SHA-256"]
 
         for hashname in hashes:
             mechanism = "SCRAM-{}-PLUS".format(hashname)
@@ -420,36 +418,26 @@ class TestSCRAMNegotiation(unittest.TestCase):
 
     def test_pick_longest_hash_SCRAM(self):
         self.assertEqual(
-            ("SCRAM-SHA-512", "sha512"),
+            ("SCRAM-SHA-256", "sha256"),
             aiosasl.SCRAM.any_supported([
                 "SCRAM-SHA-1",
-                "SCRAM-SHA-512",
-                "SCRAM-SHA-224",
+                "SCRAM-SHA-256",
                 "PLAIN",
             ])
         )
 
+    def test_no_support_for_unregistered_functions(self):
         self.assertEqual(
             ("SCRAM-SHA-256", "sha256"),
             aiosasl.SCRAM.any_supported([
                 "SCRAM-SHA-1",
                 "SCRAM-SHA-256",
-                "SCRAM-SHA-224",
+                "SCRAM-SHA-512",
                 "PLAIN",
             ])
         )
 
     def test_pick_longest_hash_SCRAMPLUS(self):
-        self.assertEqual(
-            ("SCRAM-SHA-512-PLUS", "sha512"),
-            aiosasl.SCRAMPLUS.any_supported([
-                "SCRAM-SHA-1-PLUS",
-                "SCRAM-SHA-512-PLUS",
-                "SCRAM-SHA-224-PLUS",
-                "PLAIN",
-            ])
-        )
-
         self.assertEqual(
             ("SCRAM-SHA-256-PLUS", "sha256"),
             aiosasl.SCRAMPLUS.any_supported([
@@ -471,8 +459,7 @@ class TestSCRAMNegotiation(unittest.TestCase):
             )
 
     def test_reject_scram_SCRAMPLUS(self):
-        hashes = ["SHA-1", "SHA-224", "SHA-256",
-                  "SHA-512", "SHA-384", "SHA-256"]
+        hashes = ["SHA-1", "SHA-256"]
 
         for hashname in hashes:
             mechanism = "SCRAM-{}".format(hashname)


### PR DESCRIPTION
The following SCRAM variants were previously supported by aiosasl,
but not specified in any IETF document:

* SCRAM-SHA-224(-PLUS)
* SCRAM-SHA-384(-PLUS)
* SCRAM-SHA-512(-PLUS)

The only SCRAM-SHA-* specifications are:

* RFC 7677 <https://tools.ietf.org/html/rfc7677> (SCRAM-SHA-256) and
* RFC 5802 <https://tools.ietf.org/html/rfc5802> (SCRAM-SHA-1).

Of those, RFC 7677 (which defines the registry) explicitly states:

> Note: Members of this family MUST be explicitly registered using
> the "IETF Review" [RFC5226] registration procedure.  Reviews MUST
> be requested on the KITTEN mailing list kitten@ietf.org (or a
> successor designated by the responsible Security Area Director).
>
> […]
>
> Note to future SASL SCRAM mechanism designers: each new SASL
> SCRAM mechanism MUST be explicitly registered with IANA and MUST
> comply with the SCRAM-mechanism naming convention defined in
> Section 4 of [RFC5802].

So while the unspecified mechanisms outlined above adhere to the
naming convention, they’re  not registered with the IANA (see
<https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml>)
at this point in time.

This is thus a violation of the specification/unauthorized
extension of the registered set of algorithms for no good reason.
We should drop them to stay within the specification.

In addition, an argument can be made that it’s not our place to
invent new SCRAM variants without review.

Fixes #6.