### PR TITLE
Fix use of SASLprep

### DIFF
--- a/aiosasl/__init__.py
+++ b/aiosasl/__init__.py
@@ -603,8 +603,11 @@ class PLAIN(SASLMechanism):
     def authenticate(self, sm, mechanism):
         logger.info("attempting PLAIN mechanism")
         username, password = yield from self._credential_provider()
-        username = saslprep(username).encode("utf8")
-        password = saslprep(password).encode("utf8")
+        username = username.encode("utf8")
+        password = password.encode("utf8")
+
+        if b"\0" in username or b"\0" in password:
+            raise ValueError("NUL byte in username or password is disallowed")
 
         state, _ = yield from sm.initiate(
             mechanism="PLAIN",

--- a/aiosasl/__init__.py
+++ b/aiosasl/__init__.py
@@ -713,7 +713,7 @@ class SCRAMBase:
 
         gs2_header = self._get_gs2_header()
         username, password = yield from self._credential_provider()
-        username = saslprep(username).encode("utf8")
+        username = saslprep(username, allow_unassigned=True).encode("utf8")
         password = saslprep(password).encode("utf8")
 
         our_nonce = base64.b64encode(_system_random.getrandbits(

--- a/tests/test_aiosasl.py
+++ b/tests/test_aiosasl.py
@@ -775,6 +775,21 @@ class TestSCRAM(TestSCRAMImpl, unittest.TestCase):
             aiosasl.SCRAM(self._provide_credentials)
         ))
 
+    def test_unassigned_password_codepoints(self):
+        smmock = aiosasl.SASLStateMachine(SASLInterfaceMock(
+            self,
+            []))
+
+        @asyncio.coroutine
+        def provide_credentials(*args):
+            return ("user", "\U0001f916")
+
+        with self.assertRaisesRegex(ValueError, "unassigned"):
+            self._run(
+                smmock,
+                aiosasl.SCRAM(provide_credentials)
+            )
+
     def test_unassigned_username_codepoints(self):
         smmock = aiosasl.SASLStateMachine(SASLInterfaceMock(
             self,


### PR DESCRIPTION
### Summary of changes

- Do not apply SASLprep to PLAIN authentication data (#14)
- Allow unassigned codepoints in SCRAM username (#15)

For more details, see the linked issues and the commit messages.

### Related issues

- Fixes #14 
- Fixes #15

Thanks to @iNPUTmice for bringing this up in prosody@, although it was unrelated to aiosasl.